### PR TITLE
Change Cinder's static library path

### DIFF
--- a/samples/BasicSample/xcode/BasicSample.xcodeproj/project.pbxproj
+++ b/samples/BasicSample/xcode/BasicSample.xcodeproj/project.pbxproj
@@ -386,7 +386,7 @@
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
-				OTHER_LDFLAGS = "\"$(CINDER_PATH)/lib/libcinder_d.a\"";
+				OTHER_LDFLAGS = "\"$(CINDER_PATH)/lib/macosx/$(CONFIGURATION)/libcinder.a\"";
 				PRODUCT_NAME = BasicSample;
 				SYMROOT = ./build;
 				WRAPPER_EXTENSION = app;
@@ -410,7 +410,7 @@
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
-				OTHER_LDFLAGS = "\"$(CINDER_PATH)/lib/libcinder.a\"";
+				OTHER_LDFLAGS = "\"$(CINDER_PATH)/lib/macosx/$(CONFIGURATION)/libcinder.a\"";
 				PRODUCT_NAME = BasicSample;
 				STRIP_INSTALLED_PRODUCT = YES;
 				SYMROOT = ./build;

--- a/samples/MultiGuiSample/xcode/MultiGuiSample.xcodeproj/project.pbxproj
+++ b/samples/MultiGuiSample/xcode/MultiGuiSample.xcodeproj/project.pbxproj
@@ -384,7 +384,7 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
-				OTHER_LDFLAGS = "\"$(CINDER_PATH)/lib/libcinder_d.a\"";
+				OTHER_LDFLAGS = "\"$(CINDER_PATH)/lib/macosx/$(CONFIGURATION)/libcinder.a\"";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.libcinder.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = MultiGuiSample;
 				SYMROOT = ./build;
@@ -411,7 +411,7 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
-				OTHER_LDFLAGS = "\"$(CINDER_PATH)/lib/libcinder.a\"";
+				OTHER_LDFLAGS = "\"$(CINDER_PATH)/lib/macosx/$(CONFIGURATION)/libcinder.a\"";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.libcinder.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = MultiGuiSample;
 				STRIP_INSTALLED_PRODUCT = YES;


### PR DESCRIPTION
This gets the block compiling on OS X with what's in Cinder's master branch.

Per http://discourse.libcinder.org/t/rfc-android-linux-merge/451