### PR TITLE
Add basic installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Made with the goal of creating a super simple to setup gui that looks nice.  Fea
 
 ![PretzelGui Screenshot](https://raw.githubusercontent.com/cwhitney/PretzelGui/master/ss.png)
 
+## Installation
+
+Download or check out this repoistory into your `Cinder/blocks` directory, then use [Tinderbox](https://libcinder.org/docs/guides/tinderbox/) to create a new project using the block.
+
 ----
 The MIT License (MIT)
 


### PR DESCRIPTION
One of the things I love about Node.js modules is they cover super basic stuff like installation in the readme. You read right over it when you're experienced but when you're getting started that little hint saves you 20 minutes of Googling. 

So in that spirit I submit this addition.