### PR TITLE
Fix override warnings

### DIFF
--- a/src/components/PretzelRow.h
+++ b/src/components/PretzelRow.h
@@ -17,7 +17,7 @@ namespace pretzel{
 	class PretzelRow : public BasePretzel {
 	public:
 		PretzelRow(BasePretzel *base, int width, int height);
-		void draw();
+		virtual void draw() override;
 
 	protected:
 		void updateChildrenBounds() override;

--- a/src/components/ScrollPane.h
+++ b/src/components/ScrollPane.h
@@ -19,7 +19,7 @@ namespace pretzel {
     class ScrollPane : public PretzelRow {
       public:
         ScrollPane(BasePretzel *base, int width, int height);
-        virtual void draw();
+        virtual void draw() override;
         
         virtual void mouseDown(const ci::vec2 &pos) override;
 		virtual void mouseDragged(const ci::vec2 &pos) override;


### PR DESCRIPTION
When compiling under Xcode I was seeing the following warnings:
```
In file included from /Users/andrew/projects/Cinder/blocks/PretzelGui/src/components/PretzelRoot.cpp:9:
In file included from /Users/andrew/projects/Cinder/blocks/PretzelGui/src/components/PretzelRoot.h:14:
In file included from ../../../src/pretzel/PretzelGui.h:20:
In file included from ../../../src/components/ScrollPane.h:13:
../../../src/components/PretzelRow.h:20:8: warning: 'draw' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
                void draw();
                     ^
In file included from /Users/andrew/projects/Cinder/blocks/PretzelGui/src/components/PretzelRoot.cpp:9:
In file included from /Users/andrew/projects/Cinder/blocks/PretzelGui/src/components/PretzelRoot.h:14:
In file included from ../../../src/pretzel/PretzelGui.h:19:
../../../src/components/BasePretzel.h:22:22: note: overridden virtual function is here
        virtual void draw() {};
                     ^
In file included from /Users/andrew/projects/Cinder/blocks/PretzelGui/src/components/PretzelRoot.cpp:9:
In file included from /Users/andrew/projects/Cinder/blocks/PretzelGui/src/components/PretzelRoot.h:14:
In file included from ../../../src/pretzel/PretzelGui.h:20:
../../../src/components/ScrollPane.h:22:22: warning: 'draw' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
        virtual void draw();
                     ^
In file included from /Users/andrew/projects/Cinder/blocks/PretzelGui/src/components/PretzelRoot.cpp:9:
In file included from /Users/andrew/projects/Cinder/blocks/PretzelGui/src/components/PretzelRoot.h:14:
In file included from ../../../src/pretzel/PretzelGui.h:20:
In file included from ../../../src/components/ScrollPane.h:13:
../../../src/components/PretzelRow.h:20:8: note: overridden virtual function is here
                void draw();
                     ^
2 warnings generated.
```

The fix seemed pretty straight forward.